### PR TITLE
Conditions Merge

### DIFF
--- a/source_jsons/main/conditions.json
+++ b/source_jsons/main/conditions.json
@@ -116,7 +116,7 @@
         "items": 
         [
             "Numb can be applied multiple times. A numb creature loses 5 feet of movement speed and 1 Charisma for each numb effect applied to them.",
-            "If a creature has 0 movement speed or charisma as a result of the numb effect, that creature loses all numb affecting them and becomes {@condition Listless}.",
+            "If a creature has 0 movement speed or charisma as a result of the numb effect, that creature loses all numb affecting them and becomes {@condition listless|Starlight}.",
             "If numb is not applied to a creature for an hour, that creature loses one numb effect, and another for each hour that passes thereafter."
         ]
         }
@@ -134,7 +134,7 @@
         [
             "A listless creature falls {@condition prone}, becomes {@condition incapacitated} and cannot move.",
             "The condition ends if the listless creature expends inspiration, they take more than 20 damage in one attack, or an ally spends an action to help them recover.",
-            "When this condition ends, the creature gains two {@condition numb} effects. The first turn after this ends, the creature can stand from prone at the cost of only 5 feet of movement, as they quickly snap to their senses."
+            "When this condition ends, the creature gains two {@condition numb|Starlight} effects. The first turn after this ends, the creature can stand from prone at the cost of only 5 feet of movement, as they quickly snap to their senses."
         ]
         }
     ]

--- a/source_jsons/main/conditions.json
+++ b/source_jsons/main/conditions.json
@@ -1,0 +1,143 @@
+{
+"_meta": 
+{
+    "sources": 
+    [
+        {
+            "json": "S: Conditions",
+            "abbreviation": "S: Conditions",
+            "full": "Starlight: Conditions",
+            "authors": [
+                "Mika Rae"
+            ],
+            "convertedBy": [
+                "Mika Rae"
+            ],
+            "version": "1.0",
+            "url": "https://github.com/TeraMika/starlight-homebrew",
+            "targetSchema": "1.0"
+        }
+    ],
+    "dateAdded": 0,
+    "dateLastModified": 0
+},
+
+"condition": 
+[
+    {
+	"name": "Disoriented",
+	"source": "Starlight",
+	"page": 0,
+	"entries": 
+    [
+		{
+        "type": "list",
+        "items": 
+        [
+            "A disoriented creature can only do one of the following on their turn: move, use an action, or use a bonus action.",
+            "If a creature becomes disoriented during their turn, their turn ends."
+        ]
+		}
+	]
+    },
+    {
+    "name": "Dazed",
+    "source": "Starlight",
+    "page": 0,
+    "entries": 
+    [
+        {
+        "type": "list",
+        "items": 
+        [
+            "A dazed creature is {@condition incapacitated} and cannot move.",
+            "The creature automatically fails Strength and Dexterity saving throws.",
+            "Attack rolls against the creature have advantage.",
+            "The condition can be ended on a creature if another creature spends their action to help them recover."
+        ]
+        }
+    ]
+    },
+    {
+    "name": "Weakened",
+    "source": "Starlight",
+    "page": 0,
+    "entries": 
+    [
+        {
+        "type": "list",
+        "items": 
+        [
+            "A weakened creature suffers a -2 to attack rolls, damage rolls, and saving throws.",
+            "Other creatures have advantage on any saving throw they make against a weakened creature or their effects."
+        ]
+        }
+    ]
+    },
+    {
+    "name": "Exposed",
+    "source": "Starlight",
+    "page": 0,
+    "entries": 
+    [
+        {
+        "type": "list",
+        "items": 
+        [
+            "Successful attacks against an exposed creature count as a critical hit.",
+        ]
+        }
+    ]
+    },
+    {
+    "name": "Marked",
+    "source": "Starlight",
+    "page": 0,
+    "entries": 
+    [
+        {
+        "type": "list",
+        "items": 
+        [
+            "Attack rolls against a marked creature have advantage, unless that creature takes the dodge action, which negates this effect and provides disadvantage as normal.",
+            "Marked can be applied multiple times, denoted as 'Marked (X)', and each marked effect ends after one attack. For example, 'Marked (3)' would last for 3 attacks."
+        ]
+        }
+    ]
+    },
+    {
+    "name": "Numb",
+    "source": "Starlight",
+    "page": 0,
+    "entries": 
+    [
+        {
+        "type": "list",
+        "items": 
+        [
+            "Numb can be applied multiple times. A numb creature loses 5 feet of movement speed and 1 Charisma for each numb effect applied to them.",
+            "If a creature has 0 movement speed or charisma as a result of the numb effect, that creature loses all numb affecting them and becomes {@condition Listless}.",
+            "If numb is not applied to a creature for an hour, that creature loses one numb effect, and another for each hour that passes thereafter."
+        ]
+        }
+    ]
+    },
+    {
+    "name": "Listless",
+    "source": "Starlight",
+    "page": 0,
+    "entries": 
+    [
+        {
+        "type": "list",
+        "items": 
+        [
+            "A listless creature falls {@condition prone}, becomes {@condition incapacitated} and cannot move.",
+            "The condition ends if the listless creature expends inspiration, they take more than 20 damage in one attack, or an ally spends an action to help them recover.",
+            "When this condition ends, the creature gains two {@condition numb} effects. The first turn after this ends, the creature can stand from prone at the cost of only 5 feet of movement, as they quickly snap to their senses."
+        ]
+        }
+    ]
+    }
+]
+}

--- a/source_jsons/main/conditions.json
+++ b/source_jsons/main/conditions.json
@@ -84,7 +84,7 @@
         "type": "list",
         "items": 
         [
-            "Successful attacks against an exposed creature count as a critical hit.",
+            "Successful attacks against an exposed creature count as a critical hit."
         ]
         }
     ]


### PR DESCRIPTION
Closes #5 

There is some consideration as to whether I should have the source read 'Starlight' or 'S: Conditions'.

I think I should choose now which method I prefer.
- Core rules additions is okay to have just `Starlight`, such as conditions, basic actions, non-setting-specific items or spells
- If an addition involves optional features outside of itself (such as a class adding its own invocations-style mechanic or spells) they can have the source `Starlight: <content>` or `S:<content>`.
- A collection of similar features might be grouped anyway, such as `Starlight: Kinesics`.
- Tides content will have `SToD` as the source, such as sunshards or certain species.